### PR TITLE
chore(repo): pull_request_target instead of pull_request

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
-          ref: ${{ github.event.pull_request.head.ref }}
+          ref: ${{ github.event.pull_request_target.head.ref }}
           fetch-depth: 0
       - name: Derive appropriate SHAs for base and head for `nx affected` commands
         uses: nrwl/nx-set-shas@v2


### PR DESCRIPTION
This will allow PRs from forks  to work with the CI
https://github.blog/2020-08-03-github-actions-improvements-for-fork-and-pull-request-workflows/